### PR TITLE
Switch to HTTPS in CSS @import

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,3 +1,3 @@
 /* Frontend styles */
 
-@import url("http://assets.okfn.org/themes/okfn/okf-panel.css");
+@import url("https://assets.okfn.org/themes/okfn/okf-panel.css");


### PR DESCRIPTION
This PR fixes the HTTP URL in frontend.css, which causes mixed content warnings across OKI pages.